### PR TITLE
Switch to maintained version of Java JDK

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,11 +16,11 @@ jobs:
     - name: Node
       uses: actions/setup-node@v1
 
-    - name: Use specific Java version for sdkmanager to work
-      uses: joschi/setup-jdk@v1
+    - name: Install Java JDK
+      uses: actions/setup-java@v3
       with:
-        java-version: 'openjdk8'
-        architecture: 'x64'
+        distribution: 'temurin'
+        java-version: '8'
 
     - name: Download Android Emulator Image
       run: |


### PR DESCRIPTION
I saw that one of the tests was failing in the `master` branch, so I thought I'd suggest this config, which is what I have been using successfully